### PR TITLE
Cope with long environment variables that are wrapped over multiple lines

### DIFF
--- a/subr/build_init.subr
+++ b/subr/build_init.subr
@@ -47,7 +47,7 @@ build_init() {
 		DEFAULT_GIT_ARGS="-6${DEFAULT_GIT_ARGS:+ ${DEFAULT_GIT_ARGS}}";
 		DEFAULT_WGET_ARGS="-6${DEFAULT_WGET_ARGS:+ ${DEFAULT_WGET_ARGS}}";
 	fi;
-	_env_vars="$(export | sed -e 's/^export //' -e 's/=.*$//')";
+	_env_vars="$(export | grep ^export | sed -e 's/^export //' -e 's/=.*$//')";
 	_env_vars_except="${DEFAULT_CLEAR_ENV_VARS_EXCEPT}";
 	for _env_var in ${_env_vars}; do
 		if [ "${_env_var#DEFAULT_}" != "${_env_var}" ]\


### PR DESCRIPTION
The TERMCAP variable, if present, can be very long (27 lines and
over 1500 chars in my case).

In these cases, the earlier lines end with a backslash, and the
following ones start with a one tab indent.

Filter for lines starting with "export" to properly find the
variable names only, as that's the only thing we're interested in
here.