### PR TITLE
Remove incorrect --host=${DEFAULT_TARGET} when building host tools/libraries

### DIFF
--- a/vars/build.vars
+++ b/vars/build.vars
@@ -148,7 +148,7 @@ gl_cv_C_locale_sans_EILSEQ=yes"};
 # Build target host_tools
 #
 HOST_TOOLS_BUILD_TYPE="host";
-HOST_TOOLS_CONFIGURE_ARGS="--disable-nls --host=${DEFAULT_TARGET} --prefix= --target=${DEFAULT_TARGET}";
+HOST_TOOLS_CONFIGURE_ARGS="--disable-nls --prefix= --target=${DEFAULT_TARGET}";
 HOST_TOOLS_PACKAGES="
 chainport_host slibtool_host mdso_host mpackage_host perk_host install_strip_host pkgconf_host";
 HOST_TOOLS_PREFIX="${PREFIX}";
@@ -156,7 +156,7 @@ HOST_TOOLS_PREFIX="${PREFIX}";
 : ${PKG_CHAINPORT_HOST_BUILD_STEPS_DISABLE:=build};
 : ${PKG_CHAINPORT_HOST_NO_LOG_VARS:=1};
 : ${PKG_SLIBTOOL_HOST_URLS_GIT:="slibtool=${DEFAULT_GITROOT}/slibtool"};
-: ${PKG_SLIBTOOL_HOST_CONFIGURE_ARGS:=--host= --prefix=};
+: ${PKG_SLIBTOOL_HOST_CONFIGURE_ARGS:=--prefix=};
 : ${PKG_MDSO_HOST_URLS_GIT:="mdso=${DEFAULT_GITROOT}/mdso"};
 : ${PKG_MDSO_HOST_CONFIGURE_ARGS:="--prefix="};
 : ${PKG_MDSO_HOST_INSTALL_FILES:="@mdso=bin/${DEFAULT_TARGET}-mdso /=${DEFAULT_TARGET}/bin bin/mdso=${DEFAULT_TARGET}/bin/mdso"};
@@ -224,7 +224,7 @@ HOST_TOOLS_RPM_PREFIX="${PREFIX}";
 # Build target host_toolchain_deps
 #
 HOST_TOOLCHAIN_DEPS_BUILD_TYPE="host";
-HOST_TOOLCHAIN_DEPS_CONFIGURE_ARGS="--disable-nls --host=${DEFAULT_TARGET} --prefix= --target=${DEFAULT_TARGET}";
+HOST_TOOLCHAIN_DEPS_CONFIGURE_ARGS="--disable-nls --prefix=";
 HOST_TOOLCHAIN_DEPS_PACKAGES="
 gmp_host mpfr_host mpc_host psxtypes_host";
 HOST_TOOLCHAIN_DEPS_PREFIX="${PREFIX_CROSS}";
@@ -249,7 +249,7 @@ HOST_TOOLCHAIN_DEPS_PREFIX="${PREFIX_CROSS}";
 # Build target host_toolchain
 #
 HOST_TOOLCHAIN_BUILD_TYPE="host";
-HOST_TOOLCHAIN_CONFIGURE_ARGS="--disable-nls --host=${DEFAULT_TARGET} --prefix= --target=${DEFAULT_TARGET}";
+HOST_TOOLCHAIN_CONFIGURE_ARGS="--disable-nls --prefix= --target=${DEFAULT_TARGET}";
 HOST_TOOLCHAIN_PACKAGES="
 binutils_host gcc_stage1_host psxstub_host musl_no_complex_host gcc_runtime_host
 musl_full_host ldso_host gcc_libstdcpp_v3_host gcc_full_host nasm_host";
@@ -305,7 +305,7 @@ HOST_TOOLCHAIN_PREFIX="${PREFIX_CROSS}";
 : ${PKG_LDSO_HOST_URLS_GIT:=pemagine=${DEFAULT_GITROOT}/pemagine};
 : ${PKG_LDSO_HOST_BUILD_TYPE:=cross};
 : ${PKG_LDSO_HOST_CFLAGS_CONFIGURE_EXTRA:="-O0 -DPE_LDSO -I${PREFIX_CROSS}/include"};
-: ${PKG_LDSO_HOST_CONFIGURE_ARGS:="--host=${DEFAULT_TARGET} --prefix= --target=${DEFAULT_TARGET} --disable-shared"};
+: ${PKG_LDSO_HOST_CONFIGURE_ARGS:="--prefix= --target=${DEFAULT_TARGET} --disable-shared"};
 : ${PKG_LDSO_HOST_INSTALL_FILES:="@../${DEFAULT_TARGET}/lib/libldso.a=${PREFIX}/lib/libldso.a"};
 : ${PKG_LDSO_HOST_MAKEFLAGS_BUILD_EXTRA:=STATIC_LIB_NAME=libldso.a};
 : ${PKG_LDSO_HOST_MAKEFLAGS_INSTALL_EXTRA:=STATIC_LIB_NAME=libldso.a};
@@ -329,7 +329,7 @@ HOST_TOOLCHAIN_PREFIX="${PREFIX_CROSS}";
 # Build target host_toolchain_mingw32
 #
 HOST_TOOLCHAIN_MINGW32_BUILD_TYPE="host";
-HOST_TOOLCHAIN_MINGW32_CONFIGURE_ARGS="--disable-nls --host=${DEFAULT_TARGET} --prefix=${PREFIX} --target=x86_64-w64-mingw32";
+HOST_TOOLCHAIN_MINGW32_CONFIGURE_ARGS="--disable-nls --prefix=${PREFIX} --target=x86_64-w64-mingw32";
 HOST_TOOLCHAIN_MINGW32_PACKAGES="
 binutils_host_mingw32 gcc_stage1_cross_mingw32";
 HOST_TOOLCHAIN_MINGW32_TARGET="x86_64-w64-mingw32";


### PR DESCRIPTION
When passing --host to autoconf build systems, it means that one
wants to build code that is going to run on this specific target.

When building host tools/libraries, we're building code that is
going to run on the current host system, not ${DEFAULT_TARGET}.

Building with the incorrect --host parameter has appeared to work
despite this, due to other fallbacks in autoconf. When building with
--host=<triple>, autoconf first looks for <triple>-gcc, but if this
isn't found, then proceeds to use gcc and assumes this is what the
caller meant.

When building GMP, its configure script wants to inspect symbol
names, and uses a name listing tool (normally nm) for this purpose.
When building gmp_host, with the incorrect --host parameter, it
first looks for <triple>-nm, which doesn't exist. As the previously
set incorrect triple is for a Windows OS (x86_64-nt64-midipix), it
then looks for other windows type name listing tools, <triple>-dumpbin,
then unprefixed dumpbin. If dumpbin is found (I happen to have it
around, as a wine wrapper around MSVC tools, for convenience), it
is used, but then fails to inspect the ELF object files that the
compiler has used.

By removing the incorrect --host parameter, the host toolchain
deps build succeeds by not relying on autoconf implicitly doing
the right thing despite the incorrect parameter.

Also remove --target from HOST_TOOLCHAIN_DEPS_CONFIGURE_ARGS.
Adding --target when building host tools generally is correct, when
configuring tools that generate code (like binutils and gcc). For
other projects that don't generate code, --target normally has no effect.
GMP explicitly errors out if --target is set to a different value than
host (as GMP's configure script thinks the caller has made a mistake).